### PR TITLE
Passthrough `extractOpts` to tar-fs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,11 +11,11 @@ const getAgent = httpHttpsAgent({
   maxSockets: 20
 });
 
-module.exports = promisify(({url, gotOpts, dir}, callback) => {
+module.exports = promisify(({url, gotOpts, extractOpts, dir}, callback) => {
   pipe(
     got.stream(url, assign({agent: getAgent(url)}, gotOpts)),
     gunzipMaybe(),
-    extract(dir),
+    extract(dir, extractOpts),
     callback
   );
 });


### PR DESCRIPTION
Adding this so I can pass `{ strip: 1 }` to flatten single-folder tars.