### PR TITLE
Allow `got` to select the correct `Agent` for the given request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
 - '6'
+- '8'
 env: CC=clang CXX=clang++ npm_config_clang=1
 before_install: npm install -g npm@3

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,19 +1,24 @@
+import {Agent as HttpAgent} from 'http';
+import {Agent as HttpsAgent} from 'https';
 import got from 'got';
 import pipe from 'pump';
 import {extract} from 'tar-fs';
 import gunzipMaybe from 'gunzip-maybe';
-import httpHttpsAgent from 'http-https-agent';
 import assign from 'object-assign';
 import promisify from 'promisify-function';
 
-const getAgent = httpHttpsAgent({
+const agentOpts = {
   keepAlive: true,
   maxSockets: 20
-});
+};
+const agent = {
+  http: new HttpAgent(agentOpts),
+  https: new HttpsAgent(agentOpts)
+};
 
 module.exports = promisify(({url, gotOpts, extractOpts, dir}, callback) => {
   pipe(
-    got.stream(url, assign({agent: getAgent(url)}, gotOpts)),
+    got.stream(url, assign({agent}, gotOpts)),
     gunzipMaybe(),
     extract(dir, extractOpts),
     callback

--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
     "xo": "^0.16.0"
   },
   "dependencies": {
-    "got": "^6.3.0",
+    "got": "^8.3.2",
     "gunzip-maybe": "^1.3.1",
-    "http-https-agent": "^1.0.2",
     "object-assign": "^4.1.0",
     "promisify-function": "^1.3.2",
     "pump": "^1.0.1",

--- a/readme.md
+++ b/readme.md
@@ -67,8 +67,7 @@ npm test
 
 - [got](https://github.com/sindresorhus/got): Simplified HTTP requests
 - [gunzip-maybe](https://github.com/mafintosh/gunzip-maybe): Transform stream that gunzips its input if it is gzipped and just echoes it if not
-- [http-https-agent](https://github.com/kesla/http-https-agent): Get either a HTTP or HTTPS agent depending on protocol
-- [object-assign](https://github.com/sindresorhus/object-assign): ES2015 Object.assign() ponyfill
+- [object-assign](https://github.com/sindresorhus/object-assign): ES2015 `Object.assign()` ponyfill
 - [promisify-function](https://github.com/jcollado/promisify-function): Turn a callback-style function into a function that returns a promise
 - [pump](https://github.com/mafintosh/pump): pipe streams together and close all of them if one of them closes
 - [tar-fs](https://github.com/mafintosh/tar-fs): filesystem bindings for tar-stream


### PR DESCRIPTION
When a cross-protocol redirect is encountered the agent needs to be changed. There is no way to handle this at this level because the redirect is handled internally in `got`. In [`got@8.0.0`](https://github.com/sindresorhus/got/releases/tag/v8.0.0) the ability to pass multiple agents (one for each protocol) was added to solve this problem.

This also makes `http-https-agent` redundant as it is handled by `got`.

(This is exactly the same issue as https://github.com/kesla/get-npm-registry-package/pull/15)